### PR TITLE
Add Travis Continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ install:
 - ${CXX} --version
 
 before_script:
-- cd ..
 - cmake . -DCMAKE_CXX_COMPILER=${CXX} -DNDEBUG=1
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
 - ${CXX} --version
 
 before_script:
-- cmake . -DCMAKE_CXX_COMPILER=${CXX} -DNDEBUG=1
+- cmake . 
 
 script:
 # `make all` still break

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,53 @@
+# Build matrix / environment variable are explained on:
+# http://about.travis-ci.org/docs/user/build-configuration/
+# This file can be validated on: http://lint.travis-ci.org/
+
+sudo: false
+dist: trusty
+language: cpp
+
+compiler:
+  - gcc
+
+os:
+  - linux
+  - osx
+
+git:
+  submodules: false
+
+addons:
+  apt:
+      # List of whitelisted in travis packages for ubuntu-trusty can be found here:
+      #   https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-trusty
+      # List of whitelisted in travis apt-sources:
+      #   https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
+      sources:
+      - ubuntu-toolchain-r-test
+      packages:
+      - g++-5
+      - libsnappy-dev
+      - libtool
+
+install:
+
+- if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    brew update;
+    if [ -L /usr/local/include/c++ ]; then rm /usr/local/include/c++; fi;
+    brew install gcc@5;
+    brew install snappy;
+  fi
+
+# /usr/bin/gcc is stuck to old versions on both Linux and OSX.
+- if [ "$CXX" = "g++" ]; then export CXX="g++-5"; fi
+- echo ${CXX}
+- ${CXX} --version
+
+before_script:
+- cd ..
+- cmake . -DCMAKE_CXX_COMPILER=${CXX} -DNDEBUG=1
+
+script:
+# `make all` still break
+- make db_test
+- ./db_test


### PR DESCRIPTION
Add travis continuous integration. Right now `db_test` will be run for every code change to the repo.

The test is done on my fork and the status of my fork can be checked here: https://travis-ci.com/xxks-kkk/pebblesdb