### PR TITLE
Fix ambiguous arg to abs() issue in g++-7

### DIFF
--- a/src/db/db_test.cc
+++ b/src/db/db_test.cc
@@ -2234,7 +2234,7 @@ uint64_t micros() {
 }
 
 void print_timer_info(std::string msg, uint64_t a, uint64_t b) {
-	uint64_t diff = abs(a-b);
+	uint64_t diff = llabs(a-b);
 	printf("%s: %lu micros (%f ms)\n", msg.c_str(), diff, diff/1000.0);
 }
 


### PR DESCRIPTION
This is a minor fix for the failing compilation of db_test for g++ (version 7.4.0).